### PR TITLE
allow encrypted assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 go-saml
 ======
 
-[![Build Status](https://travis-ci.org/RobotsAndPencils/go-saml.svg?branch=master)](https://travis-ci.org/RobotsAndPencils/go-saml)
-
 A just good enough SAML client library written in Go. This library is by no means complete and has been developed
 to solve several specific integration efforts. However, it's a start, and it would be great to see
 it evolve into a more fleshed out implemention.
@@ -11,7 +9,7 @@ Inspired by the early work of [Matt Baird](https://github.com/mattbaird/gosaml).
 
 The library supports:
 
-* generating signed/unsigned AuthnRequests
+* generating signed AuthnRequests
 * validating signed AuthnRequests
 * generating service provider metadata
 * generating signed Responses
@@ -42,7 +40,9 @@ sp := saml.ServiceProviderSettings{
   IDPSSOURL:                   "http://idp/saml2",
   IDPSSODescriptorURL:         "http://idp/issuer",
   IDPPublicCertPath:           "idpcert.crt",
-  SPSignRequest:               "true",
+  Id:                          "entityID", // can be SP hostname without slash
+  SPSignRequest:               true,
+  IDPSignResponse:             true,
   AssertionConsumerServiceURL: "http://localhost:8000/saml_consume",
 }
 sp.Init()
@@ -105,6 +105,18 @@ response = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     httpcommon.SendBadRequest(w, "SAML attribute identifier uid missing")
     return
   }
+
+  //If is a encrypted response need decode
+  if response.IsEncrypted(){
+    err = response.Decrypt(sp.PrivateKeyPath)
+    if err != nil {
+      httpcommon.SendBadRequest(w, "SAMLResponse parse: "+err.Error())
+      return
+    }
+  }
+  // Print plain xml
+  //fmt.Printf(response.String())
+
 
   //...
 }

--- a/authnrequest.go
+++ b/authnrequest.go
@@ -84,6 +84,7 @@ func (r *AuthnRequest) Validate(publicCertPath string) error {
 func (s *ServiceProviderSettings) GetAuthnRequest() *AuthnRequest {
 	r := NewAuthnRequest()
 	r.AssertionConsumerServiceURL = s.AssertionConsumerServiceURL
+	r.Destination = s.IDPSSOURL
 	r.Issuer.Url = s.IDPSSODescriptorURL
 	r.Signature.KeyInfo.X509Data.X509Certificate.Cert = s.PublicCert()
 
@@ -116,6 +117,7 @@ func NewAuthnRequest() *AuthnRequest {
 		ID:                          id,
 		ProtocolBinding:             "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
 		Version:                     "2.0",
+		Destination:                 "", // caller must populate ar.AppSettings.Destination,
 		AssertionConsumerServiceURL: "", // caller must populate ar.AppSettings.AssertionConsumerServiceURL,
 		Issuer: Issuer{
 			XMLName: xml.Name{
@@ -255,25 +257,6 @@ func (r *AuthnRequest) CompressedEncodedSignedString(privateKeyPath string) (str
 		return "", err
 	}
 	compressed := util.Compress([]byte(signed))
-	b64XML := base64.StdEncoding.EncodeToString(compressed)
-	return b64XML, nil
-}
-
-func (r *AuthnRequest) EncodedString() (string, error) {
-	saml, err := r.String()
-	if err != nil {
-		return "", err
-	}
-	b64XML := base64.StdEncoding.EncodeToString([]byte(saml))
-	return b64XML, nil
-}
-
-func (r *AuthnRequest) CompressedEncodedString() (string, error) {
-	saml, err := r.String()
-	if err != nil {
-		return "", err
-	}
-	compressed := util.Compress([]byte(saml))
 	b64XML := base64.StdEncoding.EncodeToString(compressed)
 	return b64XML, nil
 }

--- a/authnrequest.go
+++ b/authnrequest.go
@@ -260,3 +260,22 @@ func (r *AuthnRequest) CompressedEncodedSignedString(privateKeyPath string) (str
 	b64XML := base64.StdEncoding.EncodeToString(compressed)
 	return b64XML, nil
 }
+
+func (r *AuthnRequest) EncodedString() (string, error) {
+	saml, err := r.String()
+	if err != nil {
+		return "", err
+	}
+	b64XML := base64.StdEncoding.EncodeToString([]byte(saml))
+	return b64XML, nil
+}
+
+func (r *AuthnRequest) CompressedEncodedString() (string, error) {
+	saml, err := r.String()
+	if err != nil {
+		return "", err
+	}
+	compressed := util.Compress([]byte(saml))
+	b64XML := base64.StdEncoding.EncodeToString(compressed)
+	return b64XML, nil
+}

--- a/authnresponse.go
+++ b/authnresponse.go
@@ -56,23 +56,23 @@ func (r *Response) IsEncrypted() bool {
 	}
 }
 
-func (r *Response) Decrypt(privateKeyPath string) (*Response, error) {
+func (r *Response) Decrypt(privateKeyPath string) error{
 	s := r.originalString
 
 	if r.IsEncrypted() == false {
-		return r, errors.New("missing EncryptedAssertion tag on SAML Response, is encrypted?")
+		return errors.New("missing EncryptedAssertion tag on SAML Response, is encrypted?")
 
 	}
 	plainXML, err := DecryptResponse(s, privateKeyPath)
 	if err != nil {
-		return r, err
+		return err
 	}
 	err = xml.Unmarshal([]byte(plainXML), &r)
 	if err != nil {
-		return r, err
+		return err
 	}
 
-	return r, nil
+	return nil
 
 	//return DecryptResponse(s, privateKeyPath)
 }

--- a/iDPEntityDescriptor.go
+++ b/iDPEntityDescriptor.go
@@ -13,7 +13,7 @@ func (s *ServiceProviderSettings) GetEntityDescriptor() (string, error) {
 		DS:       "http://www.w3.org/2000/09/xmldsig#",
 		XMLNS:    "urn:oasis:names:tc:SAML:2.0:metadata",
 		MD:       "urn:oasis:names:tc:SAML:2.0:metadata",
-		EntityId: s.AssertionConsumerServiceURL,
+		EntityId: s.Id,
 
 		Extensions: Extensions{
 			XMLName: xml.Name{
@@ -25,6 +25,8 @@ func (s *ServiceProviderSettings) GetEntityDescriptor() (string, error) {
 		},
 		SPSSODescriptor: SPSSODescriptor{
 			ProtocolSupportEnumeration: "urn:oasis:names:tc:SAML:2.0:protocol",
+			AuthnRequestsSigned:        fmt.Sprintf("%t",s.SPSignRequest),
+			WantAssertionsSigned:        fmt.Sprintf("%t",s.IDPSignResponse),
 			SigningKeyDescriptor: KeyDescriptor{
 				XMLName: xml.Name{
 					Local: "md:KeyDescriptor",

--- a/saml.go
+++ b/saml.go
@@ -12,12 +12,13 @@ type ServiceProviderSettings struct {
 	IDPSSODescriptorURL         string
 	IDPPublicCertPath           string
 	AssertionConsumerServiceURL string
-        SPSignRequest               bool
-
-	hasInit       bool
-	publicCert    string
-	privateKey    string
-	iDPPublicCert string
+	Id                          string
+  	SPSignRequest               bool
+	IDPSignResponse				bool
+	hasInit                     bool
+	publicCert                  string
+	privateKey                  string
+	iDPPublicCert               string
 }
 
 type IdentityProviderSettings struct {
@@ -29,7 +30,7 @@ func (s *ServiceProviderSettings) Init() (err error) {
 	}
 	s.hasInit = true
 
-        if s.SPSignRequest {
+	if s.SPSignRequest {
 		s.publicCert, err = util.LoadCertificate(s.PublicCertPath)
 		if err != nil {
 			panic(err)

--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ type AuthnRequest struct {
 	SAML                           string                `xml:"xmlns:saml,attr"`
 	SAMLSIG                        string                `xml:"xmlns:samlsig,attr"`
 	ID                             string                `xml:"ID,attr"`
+	Destination                    string                `xml:"Destination,attr"`
 	Version                        string                `xml:"Version,attr"`
 	ProtocolBinding                string                `xml:"ProtocolBinding,attr"`
 	AssertionConsumerServiceURL    string                `xml:"AssertionConsumerServiceURL,attr"`
@@ -23,7 +24,7 @@ type AuthnRequest struct {
 
 type Issuer struct {
 	XMLName xml.Name
-	SAML    string `xml:"xmlns:saml,attr"`
+	SAML    string `xml:"xmlns:saml2,attr"`
 	Url     string `xml:",innerxml"`
 }
 
@@ -68,9 +69,13 @@ type SignatureValue struct {
 
 type KeyInfo struct {
 	XMLName  xml.Name
-	X509Data X509Data `xml:",innerxml"`
+	X509Data X509Data
 }
 
+type KeyInfoMain struct {
+	XMLName      xml.Name     `xml:"KeyInfo"`
+	EncryptedKey EncryptedKey `xml:"EncryptedKey,omitempty"`
+}
 type CanonicalizationMethod struct {
 	XMLName   xml.Name
 	Algorithm string `xml:"Algorithm,attr"`
@@ -91,7 +96,7 @@ type SamlsigReference struct {
 
 type X509Data struct {
 	XMLName         xml.Name
-	X509Certificate X509Certificate `xml:",innerxml"`
+	X509Certificate X509Certificate
 }
 
 type Transforms struct {
@@ -141,6 +146,8 @@ type Extensions struct {
 type SPSSODescriptor struct {
 	XMLName                    xml.Name
 	ProtocolSupportEnumeration string `xml:"protocolSupportEnumeration,attr"`
+	AuthnRequestsSigned        string `xml:"AuthnRequestsSigned,attr"`
+	WantAssertionsSigned       string `xml:"WantAssertionsSigned,attr"`
 	SigningKeyDescriptor       KeyDescriptor
 	EncryptionKeyDescriptor    KeyDescriptor
 	// SingleLogoutService        SingleLogoutService `xml:"SingleLogoutService"`
@@ -186,12 +193,45 @@ type Response struct {
 	IssueInstant string `xml:"IssueInstant,attr"`
 	InResponseTo string `xml:"InResponseTo,attr"`
 
-	Assertion Assertion `xml:"Assertion"`
-	Signature Signature `xml:"Signature"`
-	Issuer    Issuer    `xml:"Issuer"`
-	Status    Status    `xml:"Status"`
+	EncryptedAssertion EncryptedAssertion `xml:"EncryptedAssertion,omitempty"`
+	Assertion          Assertion          `xml:"Assertion,omitempty"`
+	Signature          Signature          `xml:"Signature"`
+	Issuer             Issuer             `xml:"Issuer"`
+	Status             Status             `xml:"Status"`
 
 	originalString string
+}
+
+type EncryptedAssertion struct {
+	XMLName       xml.Name
+	EncryptedData EncryptedData
+	Assertion     Assertion `xml:"Assertion`
+}
+
+type EncryptedData struct {
+	XMLName          xml.Name
+	EncryptionMethod EncryptionMethod
+	KeyInfo          KeyInfoMain `xml:"KeyInfo"`
+	CipherData       CipherData
+}
+
+type EncryptionMethod struct {
+	XMLName      xml.Name
+	Algorithm    string `xml:"Algorithm,attr"`
+	DigestMethod DigestMethod
+}
+
+type EncryptedKey struct {
+	XMLName          xml.Name
+	ID               string `xml:"Id,attr"`
+	EncryptionMethod EncryptionMethod
+	KeyInfo          KeyInfo
+	CipherData       CipherData
+}
+
+type CipherData struct {
+	XMLName     xml.Name
+	CipherValue string `xml:"CipherValue"`
 }
 
 type Assertion struct {

--- a/xmlsec.go
+++ b/xmlsec.go
@@ -27,6 +27,24 @@ func SignResponse(xml string, privateKeyPath string) (string, error) {
 	return sign(xml, privateKeyPath, xmlResponseID)
 }
 
+// DecryptResponse decrypt a SAML 2.0 xml using his private key
+func DecryptResponse(xml string, privateKeyPath string) (string, error) {
+	return decrypt(xml, privateKeyPath)
+}
+
+func decrypt(xml string, privateKeyPath string) (string, error) {
+
+	tempfile, err := ioutil.TempFile(os.TempDir(), "saml-resp")
+	ioutil.WriteFile(tempfile.Name(), []byte(xml), 0644)
+	plainXML, err := exec.Command("xmlsec1", "--decrypt", "--privkey-pem", privateKeyPath, tempfile.Name()).CombinedOutput()
+	defer deleteTempFile(tempfile.Name())
+	if err != nil {
+		return "", errors.New(err.Error() + " : " + string(plainXML))
+	}
+
+	return strings.Trim(string(plainXML), "\n"), nil
+}
+
 func sign(xml string, privateKeyPath string, id string) (string, error) {
 
 	samlXmlsecInput, err := ioutil.TempFile(os.TempDir(), "tmpgs")


### PR DESCRIPTION
allow require from IDP encrypt the SAML 2.0 authentication response using a certificate
allow decrypt SAML authentication response - no test case :( 
