### PR TITLE
updates for ADFS SAML to work

### DIFF
--- a/types.go
+++ b/types.go
@@ -6,18 +6,18 @@ type AuthnRequest struct {
 	XMLName                        xml.Name
 	SAMLP                          string                `xml:"xmlns:samlp,attr"`
 	SAML                           string                `xml:"xmlns:saml,attr"`
-	SAMLSIG                        string                `xml:"xmlns:samlsig,attr"`
+	SAMLSIG                        string                `xml:"xmlns:samlsig,attr,omitempty"`
 	ID                             string                `xml:"ID,attr"`
 	Version                        string                `xml:"Version,attr"`
 	ProtocolBinding                string                `xml:"ProtocolBinding,attr"`
 	AssertionConsumerServiceURL    string                `xml:"AssertionConsumerServiceURL,attr"`
 	IssueInstant                   string                `xml:"IssueInstant,attr"`
-	AssertionConsumerServiceIndex  int                   `xml:"AssertionConsumerServiceIndex,attr"`
-	AttributeConsumingServiceIndex int                   `xml:"AttributeConsumingServiceIndex,attr"`
+	AssertionConsumerServiceIndex  int                   `xml:"AssertionConsumerServiceIndex,attr,omitempty"`
+	AttributeConsumingServiceIndex int                   `xml:"AttributeConsumingServiceIndex,attr,omitempty"`
 	Issuer                         Issuer                `xml:"Issuer"`
 	NameIDPolicy                   NameIDPolicy          `xml:"NameIDPolicy"`
 	RequestedAuthnContext          RequestedAuthnContext `xml:"RequestedAuthnContext"`
-	Signature                      Signature             `xml:"Signature,omitempty"`
+	Signature                      *Signature            `xml:"Signature,omitempty"`
 	originalString                 string
 }
 


### PR DESCRIPTION
This is a few things I found I needed to do to to get this working with our ADFS SAML.  I thought it might be worth passing it back along.
- using time.RFC3339 instead of time.RFC3339Nano (according to spec
  xs:dateTime https://www.oasis-open.org/committees/download.php/35711/sstc-saml-core-errata-2.0-wd-06-diff.pdf section 1.3.3 http://books.xmlschemata.org/relaxng/ch19-77049.html) for IssueInstant
- allow for unsigned requestion creation
- omitempty for AssertionConsumerServiceIndex and
  AttributeConsumingServiceIndex
