### PR TITLE
Support multiple attribute values in response

### DIFF
--- a/authnresponse.go
+++ b/authnresponse.go
@@ -258,12 +258,14 @@ func (r *Response) AddAttribute(name, value string) {
 		},
 		Name:       name,
 		NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
-		AttributeValue: AttributeValue{
-			XMLName: xml.Name{
-				Local: "saml:AttributeValue",
+		AttributeValues: []AttributeValue{
+			{
+				XMLName: xml.Name{
+					Local: "saml:AttributeValue",
+				},
+				Type:  "xs:string",
+				Value: value,
 			},
-			Type:  "xs:string",
-			Value: value,
 		},
 	})
 }
@@ -309,8 +311,20 @@ func (r *Response) CompressedEncodedSignedString(privateKeyPath string) (string,
 func (r *Response) GetAttribute(name string) string {
 	for _, attr := range r.Assertion.AttributeStatement.Attributes {
 		if attr.Name == name || attr.FriendlyName == name {
-			return attr.AttributeValue.Value
+			return attr.AttributeValues[0].Value
 		}
 	}
 	return ""
+}
+
+func (r *Response) GetAttributeValues(name string) []string {
+	var values []string
+	for _, attr := range r.Assertion.AttributeStatement.Attributes {
+		if attr.Name == name || attr.FriendlyName == name {
+			for _, v := range attr.AttributeValues {
+				values = append(values, v.Value)
+			}
+		}
+	}
+	return values
 }

--- a/types.go
+++ b/types.go
@@ -255,11 +255,11 @@ type AttributeValue struct {
 }
 
 type Attribute struct {
-	XMLName        xml.Name
-	Name           string `xml:",attr"`
-	FriendlyName   string `xml:",attr"`
-	NameFormat     string `xml:",attr"`
-	AttributeValue AttributeValue
+	XMLName         xml.Name
+	Name            string           `xml:",attr"`
+	FriendlyName    string           `xml:",attr"`
+	NameFormat      string           `xml:",attr"`
+	AttributeValues []AttributeValue `xml:"AttributeValue"`
 }
 
 type AttributeStatement struct {


### PR DESCRIPTION
There can be multiple values inside a single attribute, e.g.

```xml
<saml:AttributeStatement>
	<saml:Attribute Name="https://aws.amazon.com/SAML/Attributes/RoleSessionName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
		<saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">my-username</saml:AttributeValue>
	</saml:Attribute>
	<saml:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
		<saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">arn:aws:iam::123456789012:role/read-only,arn:aws:iam::123456789012:saml-provider/OneLogin</saml:AttributeValue>
		<saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">arn:aws:iam::123456789012:role/read-write,arn:aws:iam::123456789012:saml-provider/OneLogin</saml:AttributeValue>
	</saml:Attribute>
</saml:AttributeStatement>
```

The current implementation of `GetAttribute` only take the 1st value. This PR is preserving this behaviour - i.e. `GetAttribute` still returns 1st value, but there's `GetAttributeValues` to get _all_ values as a slice.