### PR TITLE
Add Destination attribute

### DIFF
--- a/authnrequest.go
+++ b/authnrequest.go
@@ -84,6 +84,7 @@ func (r *AuthnRequest) Validate(publicCertPath string) error {
 func (s *ServiceProviderSettings) GetAuthnRequest() *AuthnRequest {
 	r := NewAuthnRequest()
 	r.AssertionConsumerServiceURL = s.AssertionConsumerServiceURL
+	r.Destination = s.IDPSSOURL
 	r.Issuer.Url = s.IDPSSODescriptorURL
 	r.Signature.KeyInfo.X509Data.X509Certificate.Cert = s.PublicCert()
 

--- a/types.go
+++ b/types.go
@@ -11,6 +11,7 @@ type AuthnRequest struct {
 	Version                        string                `xml:"Version,attr"`
 	ProtocolBinding                string                `xml:"ProtocolBinding,attr"`
 	AssertionConsumerServiceURL    string                `xml:"AssertionConsumerServiceURL,attr"`
+	Destination                    string                `xml:"Destination,attr"`
 	IssueInstant                   string                `xml:"IssueInstant,attr"`
 	AssertionConsumerServiceIndex  int                   `xml:"AssertionConsumerServiceIndex,attr"`
 	AttributeConsumingServiceIndex int                   `xml:"AttributeConsumingServiceIndex,attr"`


### PR DESCRIPTION
From https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf:1477

```
Destination [Optional]
A URI reference indicating the address to which this request has been sent.
This is useful to prevent malicious forwarding of requests to unintended recipients, a protection that is required by some protocol bindings.
If it is present, the actual recipient MUST check that the URI reference identifies the location at which the message was received.
If it does not, the request MUST be discarded. Some protocol bindings may require the use of this attribute (see [SAMLBind]).```