### PR TITLE
RequestedAuthnContext is nullable

### DIFF
--- a/authnrequest.go
+++ b/authnrequest.go
@@ -137,7 +137,7 @@ func NewAuthnRequest() *AuthnRequest {
 			AllowCreate: true,
 			Format:      "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
 		},
-		RequestedAuthnContext: RequestedAuthnContext{
+		RequestedAuthnContext: &RequestedAuthnContext{
 			XMLName: xml.Name{
 				Local: "samlp:RequestedAuthnContext",
 			},

--- a/types.go
+++ b/types.go
@@ -4,20 +4,20 @@ import "encoding/xml"
 
 type AuthnRequest struct {
 	XMLName                        xml.Name
-	SAMLP                          string                `xml:"xmlns:samlp,attr"`
-	SAML                           string                `xml:"xmlns:saml,attr"`
-	SAMLSIG                        string                `xml:"xmlns:samlsig,attr,omitempty"`
-	ID                             string                `xml:"ID,attr"`
-	Version                        string                `xml:"Version,attr"`
-	ProtocolBinding                string                `xml:"ProtocolBinding,attr"`
-	AssertionConsumerServiceURL    string                `xml:"AssertionConsumerServiceURL,attr"`
-	IssueInstant                   string                `xml:"IssueInstant,attr"`
-	AssertionConsumerServiceIndex  int                   `xml:"AssertionConsumerServiceIndex,attr"`
-	AttributeConsumingServiceIndex int                   `xml:"AttributeConsumingServiceIndex,attr"`
-	Issuer                         Issuer                `xml:"Issuer"`
-	NameIDPolicy                   NameIDPolicy          `xml:"NameIDPolicy"`
-	RequestedAuthnContext          RequestedAuthnContext `xml:"RequestedAuthnContext"`
-	Signature                      *Signature            `xml:"Signature,omitempty"`
+	SAMLP                          string                 `xml:"xmlns:samlp,attr"`
+	SAML                           string                 `xml:"xmlns:saml,attr"`
+	SAMLSIG                        string                 `xml:"xmlns:samlsig,attr,omitempty"`
+	ID                             string                 `xml:"ID,attr"`
+	Version                        string                 `xml:"Version,attr"`
+	ProtocolBinding                string                 `xml:"ProtocolBinding,attr"`
+	AssertionConsumerServiceURL    string                 `xml:"AssertionConsumerServiceURL,attr"`
+	IssueInstant                   string                 `xml:"IssueInstant,attr"`
+	AssertionConsumerServiceIndex  int                    `xml:"AssertionConsumerServiceIndex,attr"`
+	AttributeConsumingServiceIndex int                    `xml:"AttributeConsumingServiceIndex,attr"`
+	Issuer                         Issuer                 `xml:"Issuer"`
+	NameIDPolicy                   NameIDPolicy           `xml:"NameIDPolicy"`
+	RequestedAuthnContext          *RequestedAuthnContext `xml:"RequestedAuthnContext,omitempty"`
+	Signature                      *Signature             `xml:"Signature,omitempty"`
 	originalString                 string
 }
 


### PR DESCRIPTION
Doesn't change existing functionality, but provides a method for omitting this block for some SAML implementations.