### PR TITLE
Add support for Signature inside of Assertion block

### DIFF
--- a/authnresponse.go
+++ b/authnresponse.go
@@ -59,7 +59,7 @@ func (r *Response) Validate(s *ServiceProviderSettings) error {
 		return errors.New("no Assertions")
 	}
 
-	if len(r.Signature.SignatureValue.Value) == 0 {
+	if len(r.Signature.SignatureValue.Value) == 0 && len(r.Assertion.Signature.SignatureValue.Value) == 0 {
 		return errors.New("no signature")
 	}
 
@@ -75,7 +75,15 @@ func (r *Response) Validate(s *ServiceProviderSettings) error {
 		return errors.New("subject recipient mismatch, expected: " + s.AssertionConsumerServiceURL + " not " + r.Assertion.Subject.SubjectConfirmation.SubjectConfirmationData.Recipient)
 	}
 
-	err := VerifyResponseSignature(r.originalString, s.IDPPublicCertPath)
+	nodeNamespaceURI := ""
+
+	if len(r.Signature.SignatureValue.Value) != 0 {
+		nodeNamespaceURI = xmlResponseID
+	} else if len(r.Assertion.Signature.SignatureValue.Value) != 0 {
+		nodeNamespaceURI = xmlAssertionID
+	}
+
+	err := Verify(r.originalString, s.IDPPublicCertPath, nodeNamespaceURI)
 	if err != nil {
 		return err
 	}

--- a/types.go
+++ b/types.go
@@ -203,6 +203,7 @@ type Assertion struct {
 	SAML               string `xml:"saml,attr"`
 	IssueInstant       string `xml:"IssueInstant,attr"`
 	Issuer             Issuer `xml:"Issuer"`
+	Signature          Signature
 	Subject            Subject
 	Conditions         Conditions
 	AttributeStatement AttributeStatement

--- a/xmlsec.go
+++ b/xmlsec.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	xmlResponseID = "urn:oasis:names:tc:SAML:2.0:protocol:Response"
-	xmlRequestID  = "urn:oasis:names:tc:SAML:2.0:protocol:AuthnRequest"
+	xmlResponseID  = "urn:oasis:names:tc:SAML:2.0:protocol:Response"
+	xmlAssertionID = "urn:oasis:names:tc:SAML:2.0:assertion:Assertion"
+	xmlRequestID   = "urn:oasis:names:tc:SAML:2.0:protocol:AuthnRequest"
 )
 
 // SignRequest sign a SAML 2.0 AuthnRequest
@@ -67,17 +68,21 @@ func sign(xml string, privateKeyPath string, id string) (string, error) {
 // `publicCertPath` must be a path on the filesystem, xmlsec1 is run out of process
 // through `exec`
 func VerifyResponseSignature(xml string, publicCertPath string) error {
-	return verify(xml, publicCertPath, xmlResponseID)
+	return Verify(xml, publicCertPath, xmlResponseID)
 }
 
 // VerifyRequestSignature verify signature of a SAML 2.0 AuthnRequest document
 // `publicCertPath` must be a path on the filesystem, xmlsec1 is run out of process
 // through `exec`
 func VerifyRequestSignature(xml string, publicCertPath string) error {
-	return verify(xml, publicCertPath, xmlRequestID)
+	return Verify(xml, publicCertPath, xmlRequestID)
 }
 
-func verify(xml string, publicCertPath string, id string) error {
+func Verify(xml string, publicCertPath string, id string) error {
+	if len(id) == 0 {
+		id = xmlRequestID
+	}
+
 	//Write saml to
 	samlXmlsecInput, err := ioutil.TempFile(os.TempDir(), "tmpgs")
 	if err != nil {


### PR DESCRIPTION
The signature could be in the Assertion block in some cases. This patch adds support for this scenario.